### PR TITLE
Fixed Compilation Error on default arguments, declared twice

### DIFF
--- a/src/Observables/ObservableAnalogInput.h
+++ b/src/Observables/ObservableAnalogInput.h
@@ -25,7 +25,7 @@ private:
 };
 
 template <typename T>
-inline ObservableAnalogInput<T>::ObservableAnalogInput(uint8_t pin, uint8_t mode = INPUT)
+inline ObservableAnalogInput<T>::ObservableAnalogInput(uint8_t pin, uint8_t mode)
 {
 	this->_pin = pin;
 	pinMode(pin, mode);

--- a/src/Observables/ObservableDigitalInput.h
+++ b/src/Observables/ObservableDigitalInput.h
@@ -25,7 +25,7 @@ private:
 };
 
 template <typename T>
-inline ObservableDigitalInput<T>::ObservableDigitalInput(uint8_t pin, uint8_t mode = INPUT)
+inline ObservableDigitalInput<T>::ObservableDigitalInput(uint8_t pin, uint8_t mode)
 {
 	this->_pin = pin;
 	pinMode(pin, mode);

--- a/src/Observables/ObservableIntervalMicros.h
+++ b/src/Observables/ObservableIntervalMicros.h
@@ -42,7 +42,7 @@ private:
 };
 
 template <typename T>
-inline ObservableIntervalMicros<T>::ObservableIntervalMicros(unsigned long interval, unsigned long delay = 0)
+inline ObservableIntervalMicros<T>::ObservableIntervalMicros(unsigned long interval, unsigned long delay)
 {
 	this->__isActive = true;
 	this->_delay = delay;

--- a/src/Observables/ObservableIntervalMillis.h
+++ b/src/Observables/ObservableIntervalMillis.h
@@ -42,7 +42,7 @@ private:
 };
 
 template <typename T>
-inline ObservableIntervalMillis<T>::ObservableIntervalMillis(unsigned long interval, unsigned long delay = 0)
+inline ObservableIntervalMillis<T>::ObservableIntervalMillis(unsigned long interval, unsigned long delay)
 {
 	this->__isActive = true;
 	this->_delay = delay;

--- a/src/Observables/ObservableRange.h
+++ b/src/Observables/ObservableRange.h
@@ -28,7 +28,7 @@ private:
 };
 
 template <typename T>
-inline ObservableRange<T>::ObservableRange(T start, T end, T step = 1)
+inline ObservableRange<T>::ObservableRange(T start, T end, T step)
 {
 	this->_start = start;
 	this->_end = end;

--- a/src/Observables/ObservableRangeDefer.h
+++ b/src/Observables/ObservableRangeDefer.h
@@ -29,7 +29,7 @@ private:
 };
 
 template <typename T>
-inline ObservableRangeDefer<T>::ObservableRangeDefer(T start, T end, T step = 1)
+inline ObservableRangeDefer<T>::ObservableRangeDefer(T start, T end, T step)
 {
 	this->_start = start;
 	this->_end = end;

--- a/src/Observables/ObservableSerialFloat.h
+++ b/src/Observables/ObservableSerialFloat.h
@@ -32,7 +32,7 @@ private:
 };
 
 template <typename T>
-inline ObservableSerialFloat<T>::ObservableSerialFloat(char separator = '\n')
+inline ObservableSerialFloat<T>::ObservableSerialFloat(char separator)
 {
 	_separator = separator;
 }

--- a/src/Observables/ObservableSerialInteger.h
+++ b/src/Observables/ObservableSerialInteger.h
@@ -26,7 +26,7 @@ private:
 };
 
 template <typename T>
-inline ObservableSerialInteger<T>::ObservableSerialInteger(char separator = '\n')
+inline ObservableSerialInteger<T>::ObservableSerialInteger(char separator)
 {
 	_separator = separator;
 }

--- a/src/Observables/ObservableSerialString.h
+++ b/src/Observables/ObservableSerialString.h
@@ -25,7 +25,7 @@ private:
 };
 
 template <typename T>
-inline ObservableSerialString<T>::ObservableSerialString(char separator = '\n')
+inline ObservableSerialString<T>::ObservableSerialString(char separator)
 {
 	_separator = separator;
 }

--- a/src/Observables/ObservableTimerMicros.h
+++ b/src/Observables/ObservableTimerMicros.h
@@ -42,7 +42,7 @@ private:
 };
 
 template <typename T>
-inline ObservableTimerMicros<T>::ObservableTimerMicros(unsigned long interval, unsigned long delay = 0)
+inline ObservableTimerMicros<T>::ObservableTimerMicros(unsigned long interval, unsigned long delay)
 {
 	this->__isActive = true;
 	this->_delay = delay;

--- a/src/Observables/ObservableTimerMillis.h
+++ b/src/Observables/ObservableTimerMillis.h
@@ -42,7 +42,7 @@ private:
 };
 
 template <typename T>
-inline ObservableTimerMillis<T>::ObservableTimerMillis(unsigned long interval, unsigned long delay = 0)
+inline ObservableTimerMillis<T>::ObservableTimerMillis(unsigned long interval, unsigned long delay)
 {
 	this->__isActive = true;
 	this->_delay = delay;

--- a/src/Operators/OperatorRepeat.h
+++ b/src/Operators/OperatorRepeat.h
@@ -20,13 +20,13 @@ public:
 	void OnComplete();
 
 private:
-	size_t _N;
+	size_t N;
 };
 
 template <typename T>
 OperatorRepeat<T>::OperatorRepeat(size_t N)
 {
-	this->_N = N;
+	this->N = N;
 }
 
 template <typename T>
@@ -38,8 +38,8 @@ void OperatorRepeat<T>::OnNext(T value)
 template <typename T>
 void OperatorRepeat<T>::OnComplete()
 {
-	this->_N--;
-	if (this->_N > 0)
+	this->N--;
+	if (this->N > 0)
 	{
 		if (this->_parentObservable != nullptr) this->_parentObservable->Reset();
 	}

--- a/src/Transformations/TransformationJoin.h
+++ b/src/Transformations/TransformationJoin.h
@@ -26,7 +26,7 @@ private:
 };
 
 template <typename T>
-TransformationJoin<T>::TransformationJoin(char separator = ',')
+TransformationJoin<T>::TransformationJoin(char separator)
 {
 	_separator = String(separator);
 }

--- a/src/Transformations/TransformationSplit.h
+++ b/src/Transformations/TransformationSplit.h
@@ -26,7 +26,7 @@ private:
 };
 
 template <typename T>
-TransformationSplit<T>::TransformationSplit(char separator = ',')
+TransformationSplit<T>::TransformationSplit(char separator)
 {
 	_separator = separator;
 }


### PR DESCRIPTION
I was trying this nice lib on wemos d1 mini lite and didn't compile, I realize it was because had duplicate declarations for default argument values