### PR TITLE
Fixed compiler errors

### DIFF
--- a/examples/Blink/Blink.ino
+++ b/examples/Blink/Blink.ino
@@ -10,7 +10,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 #include "ReactiveArduinoLib.h"
 using namespace Reactive;
 
-auto timer = IntervalMillis<unsigned long>(500);
+auto timer = IntervalMillis(500);
 
 void setup()
 {

--- a/src/Observables/ObservableIntervalMicros.h
+++ b/src/Observables/ObservableIntervalMicros.h
@@ -14,7 +14,7 @@ template <typename T>
 class ObservableIntervalMicros : public Observable<unsigned long>
 {
 public:
-	ObservableIntervalMicros(unsigned long microsInterval, unsigned long delay = 0);
+	ObservableIntervalMicros(unsigned long microsInterval, unsigned long delay);
 	void Suscribe(IObserver<T> &observer) override;
 
 	void Start();

--- a/src/Observables/ObservableTimerMicros.h
+++ b/src/Observables/ObservableTimerMicros.h
@@ -14,7 +14,7 @@ template <typename T>
 class ObservableTimerMicros : public Observable<unsigned long>
 {
 public:
-	ObservableTimerMicros(unsigned long microsInterval, unsigned long delay = 0);
+	ObservableTimerMicros(unsigned long microsInterval, unsigned long delay);
 	void Suscribe(IObserver<T> &observer) override;
 
 	void Start();

--- a/src/Observables/ObservableTimerMillis.h
+++ b/src/Observables/ObservableTimerMillis.h
@@ -14,7 +14,7 @@ template <typename T>
 class ObservableTimerMillis : public Observable<unsigned long>
 {
 public:
-	ObservableTimerMillis(unsigned long microsInterval, unsigned long delay = 0);
+	ObservableTimerMillis(unsigned long microsInterval, unsigned long delay);
 	void Suscribe(IObserver<T> &observer) override;
 
 	void Start();

--- a/src/ReactiveArduinoLib.h
+++ b/src/ReactiveArduinoLib.h
@@ -77,12 +77,12 @@ namespace Reactive
 
 	inline auto TimerMillis(unsigned long interval) -> ObservableTimerMillis<unsigned long>&
 	{
-		return *(new ObservableTimerMillis<unsigned long>(interval));
+		return *(new ObservableTimerMillis<unsigned long>(interval, 0));
 	}
 
 	inline auto TimerMicros(unsigned long interval) -> ObservableTimerMicros<unsigned long>&
 	{
-		return *(new ObservableTimerMicros<unsigned long>(interval));
+		return *(new ObservableTimerMicros<unsigned long>(interval, 0));
 	}
 
 	inline auto IntervalMillis(unsigned long interval, unsigned long delay = 0) -> ObservableIntervalMillis<unsigned long>&


### PR DESCRIPTION
Not all compilers support default arguments in templates. This was an issue when compiling for ESP32.
This can be overcome using the -fpermissive flag but this is bad practice.
In this pull request the default arguments are removed for the delay and added when required.